### PR TITLE
Since backslash is File.separator on Windows, replaceAll api fails in windows

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/fstrigger/service/FSTriggerFileNameGetFileService.java
+++ b/src/main/java/org/jenkinsci/plugins/fstrigger/service/FSTriggerFileNameGetFileService.java
@@ -9,6 +9,7 @@ import org.jenkinsci.plugins.fstrigger.triggers.FileNameTriggerInfo;
 
 import java.io.File;
 import java.util.Iterator;
+import java.util.regex.Matcher;
 
 
 /**
@@ -146,7 +147,7 @@ public class FSTriggerFileNameGetFileService {
         }
 
         filePattern = filePattern.replaceAll("[\t\r\n]+", " ");
-        filePattern = filePattern.replaceAll("\\\\", File.separator);
+        filePattern = filePattern.replaceAll("\\\\", Matcher.quoteReplacement(File.separator));
         filePattern = filePattern.trim();
 
         return filePattern;


### PR DESCRIPTION
Since backslash is File.separator on Windows, replaceAll api fails in windows since the backlash is treated as a literal replacement string. With Matcher.quoteReplacement(s), Slashes ('\') and dollar signs ('$') will be given no special meaning.
