### PR TITLE
Modernize to Jenkins 2.440.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.51</version>
+        <version>4.86</version>
     </parent>
 
     <artifactId>fstrigger</artifactId>
@@ -36,7 +36,7 @@
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/fstrigger-plugin</gitHubRepo>
         <xtrigger.api.version>0.4</xtrigger.api.version>
-        <jenkins.version>2.263.4</jenkins.version>
+        <jenkins.version>2.440.3</jenkins.version>
         <java.level>8</java.level>
         <gitHubRepo>jenkinsci/fstrigger-plugin</gitHubRepo>
     </properties>
@@ -45,8 +45,8 @@
 		<dependencies>
 			<dependency>
 				<groupId>io.jenkins.tools.bom</groupId>
-				<artifactId>bom-2.263.x</artifactId>
-				<version>984.vb5eaac999a7e</version>
+				<artifactId>bom-2.440.x</artifactId>
+				<version>3234.v5ca_5154341ef</version>
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>

--- a/src/main/java/org/jenkinsci/plugins/fstrigger/triggers/FileNameTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/fstrigger/triggers/FileNameTrigger.java
@@ -17,6 +17,7 @@ import net.sf.json.JSON;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
+import org.apache.commons.io.output.NullPrintStream;
 import org.apache.commons.jelly.XMLOutput;
 import org.jenkinsci.plugins.xtriggerapi.AbstractTrigger;
 import org.jenkinsci.plugins.xtriggerapi.XTriggerDescriptor;
@@ -42,6 +43,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * @author Gregory Boissinot
@@ -88,7 +91,8 @@ public class FileNameTrigger extends AbstractTrigger {
         try {
             FSTriggerComputeFileService service = new FSTriggerComputeFileService();
             for (FileNameTriggerInfo info : fileInfo) {
-                FilePath resolvedFile = service.computedFile(pollingNode, (Job) project, info, new XTriggerLog((StreamTaskListener) TaskListener.NULL));
+                StreamTaskListener nullTaskListener = new StreamTaskListener(NullPrintStream.INSTANCE, UTF_8);
+                FilePath resolvedFile = service.computedFile(pollingNode, (Job) project, info, new XTriggerLog(nullTaskListener));
                 if (resolvedFile != null) {
                     info.setResolvedFile(resolvedFile);
                     info.setLastModifications(resolvedFile.lastModified());


### PR DESCRIPTION
Hi!

This PR aims to move this plugin to the [recommended](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/) Jenkins baseline version.

If there are additional requirements for accepting PRs - such as additional lag time before adopting a baseline - feel free to reply in the comments.

## Testing done
Ran `mvn clean verify`.

This failed a SpotBugs rule `BC_IMPOSSIBLE_CAST`. I introduced a different `StreamingTaskListener` to make the cast work.

```
[ERROR] High: Impossible cast from hudson.model.NullTaskListener to hudson.util.StreamTaskListener in org.jenkinsci.plugins.fstrigger.triggers.FileNameTrigger.start(Node, BuildableItem, boolean, XTriggerLog) [org.jenkinsci.plugins.fstrigger.triggers.FileNameTrigger] At FileNameTrigger.java:[line 91] BC_IMPOSSIBLE_CAST
```

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

Refs: sghill-rewrite/campaigns#4

Closes #43

Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.jenkins.ModernizePlugin?organizationId=SmVua2lucyBDSQ%3D%3D